### PR TITLE
2p時のbugの解消、ヒントありかなしかの時のclearの優先度の変更

### DIFF
--- a/Assets/Prefabs/StageManager.prefab
+++ b/Assets/Prefabs/StageManager.prefab
@@ -540,7 +540,7 @@ MonoBehaviour:
   nowStageNum: 4
   WarpGate: {fileID: 1681542210}
   hintButton: {fileID: 1025811185}
-  hintObject: {fileID: 0}
+  hintObject: {fileID: 9003925250182712255}
   startSound: {fileID: 8300000, guid: af2783a29c6754734b7e29f71059f996, type: 3}
   clearNoHintSound: {fileID: 8300000, guid: bbcf987fe9d8f49af9a07b873f44091e, type: 3}
   HintSound: {fileID: 8300000, guid: 02a4dc95c0426467096d749a632d969a, type: 3}
@@ -1676,14 +1676,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 48855f253fe55414caf163e446384ae4, type: 3}
---- !u!224 &3154051366758407572 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 9003925248738146312, guid: 48855f253fe55414caf163e446384ae4, type: 3}
-  m_PrefabInstance: {fileID: 6282854970531079580}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &3154051366758407571 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 9003925248738146319, guid: 48855f253fe55414caf163e446384ae4, type: 3}
+  m_PrefabInstance: {fileID: 6282854970531079580}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &3154051366758407572 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 9003925248738146312, guid: 48855f253fe55414caf163e446384ae4, type: 3}
   m_PrefabInstance: {fileID: 6282854970531079580}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6282854970776960040
@@ -1803,13 +1803,13 @@ PrefabInstance:
       objectReference: {fileID: 21300000, guid: 4adec7cb9c0734071b213619c9c3535a, type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f6c0efdf664c04c5b8d02d53ff2ed11b, type: 3}
---- !u!224 &4501072700374853281 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 7585797399419296393, guid: f6c0efdf664c04c5b8d02d53ff2ed11b, type: 3}
-  m_PrefabInstance: {fileID: 6282854970776960040}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &4501072700374853280 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 7585797399419296392, guid: f6c0efdf664c04c5b8d02d53ff2ed11b, type: 3}
+  m_PrefabInstance: {fileID: 6282854970776960040}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &4501072700374853281 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7585797399419296393, guid: f6c0efdf664c04c5b8d02d53ff2ed11b, type: 3}
   m_PrefabInstance: {fileID: 6282854970776960040}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Scripts/Goal.cs
+++ b/Assets/Scripts/Goal.cs
@@ -11,6 +11,7 @@ public class Goal : MonoBehaviour
     StageManager StageManager;
     private GameObject GoalCircle;
     private GameObject PlayerObj;
+    private GameObject physicsObject;
     [SerializeField]
     private bool mini;
     
@@ -31,12 +32,15 @@ public class Goal : MonoBehaviour
             PlayerObj.GetComponent<Rigidbody2D>().velocity = Vector2.zero;
             PlayerObj.GetComponent<Rigidbody2D>().simulated = false;
             PlayerObj.GetComponent<CircleCollider2D>().enabled = false;
-            if (PlayerObj.TryGetComponent(out Player_Physics Physics))
+
+            var physicsObj =  GameObject.FindObjectOfType<Player_Physics>();
+            physicsObject = physicsObj.gameObject;
+            if (physicsObj != null && PlayerObj.TryGetComponent(out Player_Physics Physics))
             {
                 Physics.isCheck = false;
             }
 
-            StartCoroutine(Goalanimation());
+            StartCoroutine(Goalanimation(PlayerObj));
         }
     }
 
@@ -45,38 +49,41 @@ public class Goal : MonoBehaviour
         if (Se != null) Se.ShotSe(type);
     }
 
-    private IEnumerator Goalanimation()
+    private IEnumerator Goalanimation(GameObject targetPbPnject)
     {
         Debug.Log("goalAnime");
-        var dis = Vector3.Distance(PlayerObj.transform.position, transform.position);
+        var dis = Vector3.Distance(targetPbPnject.transform.position, transform.position);
         Debug.Log("distance = "+dis);
-        var PlayerPos = (PlayerObj.transform.position - transform.position).normalized;
+        var PlayerPos = (targetPbPnject.transform.position - transform.position).normalized;
         if(mini)
         {
-            PlayerObj.transform.localScale = new Vector3(0.2f, 0.2f, 0.2f);
-            PlayerObj.transform.DOScale(new Vector3(0.1f, 0.1f, 0.1f), 2f);
+            targetPbPnject.transform.localScale = new Vector3(0.2f, 0.2f, 0.2f);
+            targetPbPnject.transform.DOScale(new Vector3(0.1f, 0.1f, 0.1f), 2f);
         }
         else
         {
-            PlayerObj.transform.localScale = new Vector3(0.35f, 0.35f, 0.35f);
-            PlayerObj.transform.DOScale(new Vector3(0.15f, 0.15f, 0.15f), 2f);
+            targetPbPnject.transform.localScale = new Vector3(0.35f, 0.35f, 0.35f);
+            targetPbPnject.transform.DOScale(new Vector3(0.15f, 0.15f, 0.15f), 2f);
         }
-        PlayerObj.transform.DOScale(new Vector3(0.15f, 0.15f, 0.15f), 2f);
+        targetPbPnject.transform.DOScale(new Vector3(0.15f, 0.15f, 0.15f), 2f);
         for (int i = 0; i < 90; i++)
         {
             float temp = 1f * i * 4 / 360;
             //PlayerObj.transform.localScale = new Vector3(0.3f, 0.3f, 0.3f) * (1f - 1f* i / 90);
             var GoalPlayerPos = new Vector3(PlayerPos.x * dis * (1f - temp) * Mathf.Sin(temp * 15), PlayerPos.x * dis * (1f - temp) * Mathf.Cos(temp * 15), 0) + transform.position;
             Debug.Log(Mathf.Sin(i * 4 / 360));
-            PlayerObj.transform.position = GoalPlayerPos;
+            targetPbPnject.transform.position = GoalPlayerPos;
             yield return new WaitForFixedUpdate();
         }
-        var color = PlayerObj.GetComponent<SpriteRenderer>();
+        var color = targetPbPnject.GetComponent<SpriteRenderer>();
         color.color = new Color(0, 0, 0, 0);
         Destroy(this.gameObject);
         StageManager.stageClear();
+        
+        var colorS = physicsObject.GetComponent<SpriteRenderer>();
+        colorS.color = new Color(0, 0, 0, 0);
 
-        if(StageManager.useHint)
+        if (StageManager.useHint)
         {
             switch (Se.type)
             {

--- a/Assets/Scripts/StageManager.cs
+++ b/Assets/Scripts/StageManager.cs
@@ -166,17 +166,17 @@ public class StageManager : MonoBehaviour
     public void stageClear()
     {
         playNum = 0;
-        if (useHint)
-        {
-            StageClearText2.SetActive(true);
-            PlayerPrefs.SetInt(nowStage.ToString(), 1);
-        }
-        else if (!useHint)
+        if (!useHint)
         {
             PlayerPrefs.SetInt(nowStage.ToString(), 2);
             StageClearText1.SetActive(true);
             audioSource.PlayOneShot(clearNoHintSound);
             useHint = false;
+        }
+        else if (useHint)
+        {
+            StageClearText2.SetActive(true);
+            PlayerPrefs.SetInt(nowStage.ToString(), 1);
         }
         isStartAnime = false;
         PlayerPrefs.Save();


### PR DESCRIPTION
## 変更点
 - 2pの時のゴールのエフェクトの修正
 - 2pの時のゴール後破壊エフェクトが入る修正
 - ヒントありかなしかによって変わるステージチョイスの★の優先度をなしの方を高く修正